### PR TITLE
FIX:멘토링, 스케줄 캘린더에서 날짜 다시 클릭시 쿼리 실행되는 버그 수정

### DIFF
--- a/frontend/src/queries/mentoring/commonMentoringQuery.ts
+++ b/frontend/src/queries/mentoring/commonMentoringQuery.ts
@@ -30,7 +30,8 @@ export const useDailyMentoringsQuery = ({
     querykey.concat(date),
     () => getDailyMentorings({ profileId, mentorId, date }),
     {
-      enabled: mentorId !== undefined || profileId !== undefined,
+      enabled:
+        date !== "" && (mentorId !== undefined || profileId !== undefined),
       retry: false,
       staleTime: STALE_TIME.SOMETIMES,
     }
@@ -51,9 +52,8 @@ export const useMonthlyMentoringsQuery = ({
     () => getMonthlyMentorings({ profileId, mentorId, month }),
     {
       enabled:
-        ((mentorId !== undefined && mentorId !== undefined) ||
-          (profileId !== undefined && profileId !== undefined)) &&
-        month !== undefined,
+        month !== undefined &&
+        (mentorId !== undefined || profileId !== undefined),
       staleTime: STALE_TIME.SOMETIMES,
     }
   );

--- a/frontend/src/queries/scheduleQuery.ts
+++ b/frontend/src/queries/scheduleQuery.ts
@@ -19,7 +19,7 @@ const useDailySchedulesQuery = (mentorId: number, date: string) => {
     GET_DAILY_SCHEDULES_KEY.concat(date),
     () => getDailySchedules(mentorId, date),
     {
-      enabled: mentorId !== undefined && date !== undefined,
+      enabled: mentorId !== undefined && date !== "",
       retry: false,
       staleTime: STALE_TIME.OFTEN,
     }


### PR DESCRIPTION
1. enabled 옵션에 date 가 빈 문자열로 들어오는 조건 추가