### PR TITLE
FIX:JobSelector 탭 클릭시 창 닫히는 버그 수정

### DIFF
--- a/frontend/src/components/Job/JopSelector.tsx
+++ b/frontend/src/components/Job/JopSelector.tsx
@@ -44,8 +44,6 @@ const JobSelector = ({
     { name: string }[] | undefined
   >([]);
 
-  useClickOutOfInput(id!, setOpen);
-
   useEffect(() => {
     (async () => {
       const { data } = await getJobCategories<Jobs[]>();
@@ -55,7 +53,7 @@ const JobSelector = ({
   }, []);
   useEffect(() => {
     setCategorizedJobs(
-      jobs!.find((item, index) => {
+      jobs!.find((_, index) => {
         return index === selectedTab;
       })?.jobs
     );
@@ -74,6 +72,7 @@ const JobSelector = ({
           onClick={() => {
             setOpen((prev) => !prev);
           }}
+          hoverDisabled
         >
           <Truncate id={id}>{selected ? selected : "직무 카테고리"}</Truncate>
 
@@ -132,6 +131,7 @@ const Tabs = ({
               selectedTab === index ? theme.colors.primary : theme.colors.white
             }
             width="20%"
+            hoverDisabled
           >
             {category}
           </TabButton>
@@ -169,6 +169,7 @@ const TabContent = ({
             color={
               selected === name ? theme.colors.secondary : theme.colors.white
             }
+            hoverDisabled
           >
             {name}
           </Button>


### PR DESCRIPTION
* useClickOutOfInput 커스텀 훅 제거
   - 'X' 버튼이 명시적으로 있기 때문에, 해당 버튼을 통해 닫히게 하는 것이 좋다고 생각하여 수정